### PR TITLE
fix: try using Statnett BOT to overcome GHCR authorization issues

### DIFF
--- a/.github/workflows/clean-ghcr.yaml
+++ b/.github/workflows/clean-ghcr.yaml
@@ -14,6 +14,11 @@ on:
         type: string
         default: A week ago UTC
         description: The timezone-aware datetime you want to delete container versions that are older than.
+    secrets:
+      STATNETT_BOT_APP_ID:
+        required: true
+      STATNETT_BOT_PRIVATE_KEY:
+        required: true
 
 jobs:
   clean-ghcr:
@@ -21,6 +26,12 @@ jobs:
     permissions:
       packages: write
     steps:
+      - id: token
+        uses: tibdex/github-app-token@v1
+        with:
+          app_id: ${{ secrets.STATNETT_BOT_APP_ID }}
+          private_key: ${{ secrets.STATNETT_BOT_PRIVATE_KEY }}
+
       - name: Delete untagged container images according to cut-off
         uses: snok/container-retention-policy@v2
         with:
@@ -29,4 +40,4 @@ jobs:
           account-type: org
           org-name: statnett
           untagged-only: true
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ steps.token.outputs.token }}


### PR DESCRIPTION
Hoping to fix these broken workflow runs: https://github.com/statnett/k3a-lag-exporter/actions/workflows/clean-ghcr.yaml

Setup replicated from https://github.com/statnett/workflows/blob/main/.github/workflows/release-please.yml