### PR TITLE
fix: ensure all actions use exact digest version

### DIFF
--- a/.github/workflows/clean-ghcr.yaml
+++ b/.github/workflows/clean-ghcr.yaml
@@ -28,7 +28,7 @@ jobs:
       packages: write
     steps:
       - name: Delete untagged container images according to cut-off
-        uses: snok/container-retention-policy@v2
+        uses: snok/container-retention-policy@04c70fd030033036d69c0057e0d125bf25820544 # v2.1.2
         with:
           image-names: ${{ inputs.image-names }}
           cut-off: ${{ inputs.cut-off }}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -24,12 +24,12 @@ jobs:
       pull-requests: write
     steps:
       - id: token
-        uses: tibdex/github-app-token@v1
+        uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a # v2.1.2
         with:
           app_id: ${{ secrets.STATNETT_BOT_APP_ID }}
           private_key: ${{ secrets.STATNETT_BOT_PRIVATE_KEY }}
 
-      - uses: google-github-actions/release-please-action@v3
+      - uses: google-github-actions/release-please-action@4c5670f886fe259db4d11222f7dff41c1382304d # v3.7.12
         with:
           bump-minor-pre-major: ${{ inputs.bump-minor-pre-major }}
           release-type: ${{ inputs.release-type }}


### PR DESCRIPTION
I think we should use exact actions digest versions to follow best-practice. To avoid to much manual work, we could enable Renovate auto-merge.

The alternative is the other way around, and only use major version notifiers. WDYT?

Anyway we should not have a mix.